### PR TITLE
Add tests for config parser

### DIFF
--- a/tests/config_parser_test.sh
+++ b/tests/config_parser_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_writes_crontab_from_config() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/config.env" <<'CFG'
+# Sample config with spacing and comments
+ CMD_1 = /bin/echo hi # greet
+INTERVAL_1= * * * * *
+CMD_2=/bin/date
+INTERVAL_2=0 1 * * *
+CFG
+
+  CONFIG_FILE="$tmpdir/config.env" bash app/config_parser.sh
+
+  local expected=$'* * * * * /bin/echo hi\n0 1 * * * /bin/date'
+  local actual
+  actual=$(cat /etc/crontabs/root)
+  if [[ "$actual" != "$expected" ]]; then
+    echo "crontab content mismatch" >&2
+    echo "expected:" >&2
+    printf '%s\n' "$expected" >&2
+    echo "actual:" >&2
+    printf '%s\n' "$actual" >&2
+    exit 1
+  fi
+
+  rm -rf "$tmpdir"
+  rm -rf /etc/crontabs
+}
+
+test_errors_when_missing_pair() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cat >"$tmpdir/config.env" <<'CFG'
+CMD_1=/bin/echo hi
+CFG
+  if CONFIG_FILE="$tmpdir/config.env" bash app/config_parser.sh 2>"$tmpdir/err.log"; then
+    echo "script succeeded when it should have failed" >&2
+    exit 1
+  fi
+  if ! grep -q "Missing CMD_1 or INTERVAL_1" "$tmpdir/err.log"; then
+    echo "expected error message not found" >&2
+    cat "$tmpdir/err.log" >&2
+    exit 1
+  fi
+
+  rm -rf "$tmpdir"
+  rm -rf /etc/crontabs
+}
+
+test_writes_crontab_from_config
+test_errors_when_missing_pair
+
+echo "All config_parser tests passed"


### PR DESCRIPTION
## Summary
- add bash tests covering config_parser.sh cron output
- verify script errors out when command and interval pairs are incomplete

## Testing
- `bash tests/config_parser_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b42673a5ec832f91c8e64ba58812e2