### PR TITLE
chore: harden run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+# Enable strict error handling: exit on errors, undefined variables, and
+# failures within pipelines.
 
 generate_cron() {
   bash /app/config_parser.sh
@@ -12,16 +14,17 @@ reload_crond() {
 watch_config() {
   local file="$1"
   if command -v inotifywait >/dev/null 2>&1; then
-    inotifywait -m -e close_write,move,delete "$file" | while read -r _; do
-      generate_cron
-      reload_crond
-    done
+    inotifywait -m -e close_write,move,delete "$file" |
+      while read -r _; do
+        generate_cron
+        reload_crond
+      done || true
   else
     local prev
-    prev="$(md5sum "$file" 2>/dev/null | awk '{print $1}')"
+    prev="$(md5sum "$file" 2>/dev/null | awk '{print $1}' || true)"
     while sleep 5; do
       local curr
-      curr="$(md5sum "$file" 2>/dev/null | awk '{print $1}')"
+      curr="$(md5sum "$file" 2>/dev/null | awk '{print $1}' || true)"
       if [ "$curr" != "$prev" ]; then
         prev="$curr"
         generate_cron
@@ -37,8 +40,8 @@ generate_cron
 crond -f -l 2 &
 CROND_PID=$!
 
-if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+if [ -n "${CONFIG_FILE:-}" ] && [ -f "${CONFIG_FILE:-}" ]; then
   watch_config "$CONFIG_FILE" &
 fi
 
-wait $CROND_PID
+wait "$CROND_PID"


### PR DESCRIPTION
## Summary
- use `set -euo pipefail` in run script for strict error handling
- guard config file reference when unset and ignore non-critical pipeline failures

## Testing
- `bash tests/config_parser_test.sh`
- `bash test.sh` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b42c21e150832fbc81cb308bb357cd