### PR TITLE
Add ShellCheck to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: shellcheck run.sh app/config_parser.sh tests/*.sh
       - name: Run Docker build and test
         run: bash test.sh
       - name: Run watch config test


### PR DESCRIPTION
## Summary
- Install ShellCheck and run it on scripts prior to building

## Testing
- `shellcheck run.sh app/config_parser.sh tests/*.sh`
- `bash tests/watch_config_test.sh`
- `bash test.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b4512561b0832f9db3ef07aa0a20fc