### PR TITLE
Run tests without root or Docker

### DIFF
--- a/app/config_parser.sh
+++ b/app/config_parser.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+CRONTABS_DIR=${CRONTABS_DIR:-/etc/crontabs}
+
 if [ -n "$CONFIG_FILE" ]; then
   if [ ! -f "$CONFIG_FILE" ]; then
     echo "Config file $CONFIG_FILE not found" >&2
@@ -40,5 +42,5 @@ while :; do
   i=$((i + 1))
 done
 
-mkdir -p /etc/crontabs
-printf "%s\n" "${lines[@]}" > /etc/crontabs/root
+mkdir -p "$CRONTABS_DIR"
+printf "%s\n" "${lines[@]}" > "$CRONTABS_DIR/root"

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,12 @@ set -euo pipefail
 # Enable strict error handling: exit on errors, undefined variables, and
 # failures within pipelines.
 
+CONFIG_PARSER_PATH=${CONFIG_PARSER_PATH:-/app/config_parser.sh}
+CRONTABS_DIR=${CRONTABS_DIR:-/etc/crontabs}
+export CRONTABS_DIR
+
 generate_cron() {
-  bash /app/config_parser.sh
+  bash "$CONFIG_PARSER_PATH"
 }
 
 reload_crond() {
@@ -37,7 +41,7 @@ watch_config() {
 # Generate cron entries from environment/config
 generate_cron
 
-crond -f -l 2 &
+crond -f -l 2 -c "$CRONTABS_DIR" &
 CROND_PID=$!
 
 if [ -n "${CONFIG_FILE:-}" ] && [ -f "${CONFIG_FILE:-}" ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,31 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE_NAME=docker-cron-test
-LOG_FILE=test.log
-TEMP_CONFIG=config.json
+for test_file in tests/*_test.sh; do
+  echo "Running $test_file"
+  bash "$test_file"
+  echo
+done
 
-cleanup() {
-  rm -f "$TEMP_CONFIG" "$LOG_FILE"
-}
-trap cleanup EXIT
-
-# Build docker image
- docker build -t "$IMAGE_NAME" .
-
-# Create temporary config file
-cat > "$TEMP_CONFIG" <<'CFG'
-{
-  "jobs": [
-    {"cmd": "echo hello from cron", "interval": "* * * * *"}
-  ]
-}
-CFG
-
-# Run config parser inside container and display generated crontab
- docker run --rm -v "$(pwd)/$TEMP_CONFIG:/config.json" -e CONFIG_FILE=/config.json --entrypoint /bin/sh "$IMAGE_NAME" -c '/app/config_parser.sh; cat /etc/crontabs/root' | tee "$LOG_FILE"
-
-# Verify expected command is present in log
-grep -q "echo hello from cron" "$LOG_FILE"
-
-echo "Test completed successfully"
+echo "All tests passed"

--- a/tests/watch_config_test.sh
+++ b/tests/watch_config_test.sh
@@ -4,16 +4,13 @@ set -euo pipefail
 test_watch_config_updates_crontab() {
   local workdir
   workdir=$(mktemp -d)
-  mkdir -p "$workdir/bin" "$workdir/app"
-  ln -s "$(command -v busybox)" "$workdir/bin/crond"
-  ln -s "$(pwd)/run.sh" "$workdir/app/run.sh"
-  ln -s "$(pwd)/app/config_parser.sh" "$workdir/app/config_parser.sh"
-
-  if [[ -e /app ]]; then
-    rm -rf /app
-  fi
-  ln -s "$workdir/app" /app
-  local app_link_created=1
+  mkdir -p "$workdir/bin"
+  cat >"$workdir/bin/crond" <<'CRON'
+#!/usr/bin/env bash
+trap '' HUP
+while true; do sleep 1; done
+CRON
+  chmod +x "$workdir/bin/crond"
 
   cat >"$workdir/config.json" <<'CFG'
 {
@@ -23,23 +20,23 @@ test_watch_config_updates_crontab() {
 }
 CFG
 
-  PATH="$workdir/bin:$PATH" CONFIG_FILE="$workdir/config.json" /app/run.sh &
+  PATH="$workdir/bin:$PATH" CONFIG_FILE="$workdir/config.json" CRONTABS_DIR="$workdir/crontabs" CONFIG_PARSER_PATH="$(pwd)/app/config_parser.sh" setsid bash run.sh >"$workdir/run.log" 2>&1 &
   local pid=$!
 
   for _ in {1..50}; do
-    [[ -f /etc/crontabs/root ]] && break
+    [[ -f "$workdir/crontabs/root" ]] && break
     sleep 0.1
   done
 
   local expected1=$'* * * * * /bin/echo hi'
   local actual
-  actual=$(cat /etc/crontabs/root)
+  actual=$(cat "$workdir/crontabs/root")
   if [[ "$actual" != "$expected1" ]]; then
     echo "initial crontab mismatch" >&2
+    kill "$pid" 2>/dev/null || true
     kill -- -"$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     rm -rf "$workdir"
-    rm -rf /etc/crontabs
     exit 1
   fi
 
@@ -52,26 +49,23 @@ CFG
 CFG
 
   for _ in {1..50}; do
-    actual=$(cat /etc/crontabs/root)
+    actual=$(cat "$workdir/crontabs/root")
     [[ "$actual" == $'*/5 * * * * /bin/date' ]] && break
     sleep 0.2
   done
   if [[ "$actual" != $'*/5 * * * * /bin/date' ]]; then
     echo "updated crontab mismatch" >&2
+    kill "$pid" 2>/dev/null || true
     kill -- -"$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     rm -rf "$workdir"
-    rm -rf /etc/crontabs
     exit 1
   fi
 
+  kill "$pid" 2>/dev/null || true
   kill -- -"$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
   rm -rf "$workdir"
-  rm -rf /etc/crontabs
-  if [[ "$app_link_created" -eq 1 ]]; then
-    rm /app
-  fi
 }
 
 test_watch_config_updates_crontab


### PR DESCRIPTION
## Summary
- enable configurable cron output directory via `CRONTABS_DIR`
- allow `run.sh` and tests to work without Docker or root
- add root `test.sh` to run all test scripts

## Testing
- `./test.sh`
- `su tester -c 'cd /workspace/docker-cron && ./test.sh'`


------
https://chatgpt.com/codex/tasks/task_e_68b4536fdfb0832f897aae7c55cae03a